### PR TITLE
add type hint enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,13 @@ from validatedata import autovalidate
 # custom type checker for decimals
 def is_decimal(v): return isinstance(v, Decimal)
 
-
 # add at the bottom of a file you want to auto-validate
-# replace placeholder details
 autovalidate(
     module="my_project.my_module",
-    type_checkers={Decimal: is_decimal},
-    raise_exceptions=True,
+    type_checkers={Decimal: is_decimal},   # custom checkers
+    raise_exceptions=True,                 # raise on failure
+    enforce_hints=False,                   # require type hints on all functions
+    # decorator=my_custom_decorator,       # optional: use your own decorator
 )
 ```
 
@@ -263,6 +263,22 @@ report = autovalidate_package(
 # print(report["decorated"])
 
 ```
+
+### Parameters:
+
+`module` – module object or name (defaults to caller’s module)
+
+`ignore` – list of strings/regex to skip (fully qualified names)
+
+`type_checkers` – extra custom type checkers
+
+`raise_exceptions` – whether to raise ValidationError (default True)
+
+`dry_run` – if True, only return names that would be decorated
+
+`decorator` – custom decorator to use instead of validate_types (ignores type_checkers & raise_exceptions)
+
+`enforce_hints` – if True, raise TypeError for any function without type annotations
 
 ## Mirror‑structure rules
 

--- a/docs/autovalidate.rst
+++ b/docs/autovalidate.rst
@@ -56,6 +56,12 @@ Parameters
    * - ``dry_run``
      - ``False``
      - If ``True``, return list of names that would be decorated without modifying anything
+   * - ``decorator``
+     - ``None``
+     - Optional callable used in place of ``validate_types``. Must be a plain decorator (accepts a function, returns a wrapped function). When provided, ``type_checkers`` and ``raise_exceptions`` are ignored.
+   * - ``enforce_hints``
+     - ``False``
+     - If ``True``, raise ``TypeError`` for any eligible function that has no type annotations (functions already skipped by ignore lists are exempt).
 
 Returns
 ~~~~~~~
@@ -84,6 +90,54 @@ Walk a package and apply ``@validate_types`` to all matching modules.
    print(report["decorated"])      # list of decorated callables
    print(report["skipped"])        # (name, reason)
    print(report["import_errors"])  # modules that failed to import
+   
+   
+``autovalidate_package()`` parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :header-rows: 1
+    :widths: 25 15 60
+
+    * - Parameter
+    - Default
+    - Description
+    * - ``package``
+    - required
+    - Package object or dotted name
+    * - ``include``
+    - ``None``
+    - Glob/regex patterns for module or member names to include
+    * - ``exclude``
+    - ``None``
+    - Glob/regex patterns for module or member names to exclude
+    * - ``type_checkers``
+    - ``None``
+    - Custom type validators forwarded to ``validate_types``
+    * - ``raise_exceptions``
+    - ``True``
+    - Forwarded to ``validate_types``
+    * - ``dry_run``
+    - ``False``
+    - If ``True``, return what would be decorated without mutating
+    * - ``auto_register_types``
+    - ``False``
+    - Discover and register matching classes as custom types
+    * - ``default_type_name_patterns``
+    - ``('*Model', '*Entity', '*Type')``
+    - Glob patterns for class names to auto‑register
+    * - ``custom_type_patterns``
+    - ``None``
+    - Additional patterns for auto‑registration
+    * - ``post_type_validate``
+    - ``False``
+    - Call ``cls.validate(instance)`` inside auto‑registered type checkers
+    * - ``decorator``
+    - ``None``
+    - Optional callable used in place of ``validate_types`` (ignores ``type_checkers`` & ``raise_exceptions``)
+    * - ``enforce_hints``
+    - ``False``
+    - If ``True``, raise ``TypeError`` for any eligible function without type hints
 
 Advanced: auto‑register types from naming conventions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -476,3 +476,43 @@ Replace ``validate_data`` with ``validate_data_fast`` for a speed boost:
        print(result.data)   # {'username': 'alice', 'score': 95}
    else:
        print(result.errors)
+       
+----
+       
+Enforcing type hints with ``enforce_hints``
+--------------------------------------------
+
+Use ``enforce_hints=True`` to catch functions that accidentally lack type annotations.
+
+.. code-block:: python
+
+    from validatedata import autovalidate
+
+    def no_hints(a, b):   # Missing type hints
+        return a + b
+
+    def with_hints(x: int, y: int) -> int:
+        return x + y
+
+    # The following line would raise TypeError because 'no_hints' has no annotations
+    # autovalidate(enforce_hints=True)
+
+    # Instead, skip it explicitly
+    autovalidate(ignore=["__main__.no_hints"], enforce_hints=True)
+
+Using a custom decorator
+------------------------
+
+You can replace ``validate_types`` with your own decorator, for example to add logging.
+
+.. code-block:: python
+
+    from validatedata import autovalidate
+
+    def log_and_validate(fn):
+        def wrapper(*args, **kwargs):
+            print(f"Calling {fn.__name__}")
+            return fn(*args, **kwargs)
+        return wrapper
+
+    autovalidate(decorator=log_and_validate)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "validatedata"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   { name="Edward Kigozi", email="eddyk1collab@gmail.com" },
 ]

--- a/tests/test_autovalidate.py
+++ b/tests/test_autovalidate.py
@@ -231,6 +231,307 @@ class TestAutovalidate(unittest.TestCase):
         with self.assertRaises(KeyError):
             autovalidate(module="does_not_exist")
 
+    # ------------------------------------------------------------------
+    # decorator= tests
+    # ------------------------------------------------------------------
+
+    def test_custom_decorator_replaces_validate_types(self):
+        """A custom decorator is applied instead of validate_types."""
+        calls = []
+
+        def tracking_decorator(fn):
+            def wrapper(*args, **kwargs):
+                calls.append(args)
+                return fn(*args, **kwargs)
+            return wrapper
+
+        def greet(name: str) -> str:
+            return f"hi {name}"
+
+        self.test_module.greet = greet
+        autovalidate(module=self.test_module, decorator=tracking_decorator)
+
+        result = self.test_module.greet("Alice")
+        self.assertEqual(result, "hi Alice")
+        # The tracking wrapper should have been called
+        self.assertEqual(len(calls), 1)
+
+    def test_custom_decorator_receives_unannotated_functions_unchanged(self):
+        """Functions without annotations are still skipped even with a custom decorator."""
+        applied_to = []
+
+        def spy_decorator(fn):
+            applied_to.append(fn.__name__)
+            return fn
+
+        def no_hints(x, y):
+            return x + y
+
+        self.test_module.no_hints = no_hints
+        autovalidate(module=self.test_module, decorator=spy_decorator)
+
+        # no_hints has no annotations; the decorator must not have been applied
+        self.assertNotIn("no_hints", applied_to)
+
+    def test_custom_decorator_applied_to_instance_method(self):
+        """Custom decorator wraps instance methods on classes."""
+        wrapped = []
+
+        def marking_decorator(fn):
+            def wrapper(*args, **kwargs):
+                wrapped.append(fn.__name__)
+                return fn(*args, **kwargs)
+            return wrapper
+
+        class Counter:
+            def increment(self, value: int) -> int:
+                return value + 1
+
+        self.test_module.Counter = Counter
+        autovalidate(module=self.test_module, decorator=marking_decorator)
+
+        c = self.test_module.Counter()
+        self.assertEqual(c.increment(4), 5)
+        self.assertIn("increment", wrapped)
+
+    def test_custom_decorator_applied_to_classmethod(self):
+        """Custom decorator wraps classmethods."""
+        wrapped = []
+
+        def marking_decorator(fn):
+            def wrapper(*args, **kwargs):
+                wrapped.append(fn.__name__)
+                return fn(*args, **kwargs)
+            return wrapper
+
+        class Factory:
+            @classmethod
+            def create(cls, n: int):
+                return n * 10
+
+        self.test_module.Factory = Factory
+        autovalidate(module=self.test_module, decorator=marking_decorator)
+
+        result = self.test_module.Factory.create(3)
+        self.assertEqual(result, 30)
+        self.assertIn("create", wrapped)
+
+    def test_custom_decorator_applied_to_staticmethod(self):
+        """Custom decorator wraps staticmethods."""
+        wrapped = []
+
+        def marking_decorator(fn):
+            def wrapper(*args, **kwargs):
+                wrapped.append(fn.__name__)
+                return fn(*args, **kwargs)
+            return wrapper
+
+        class Util:
+            @staticmethod
+            def double(n: int) -> int:
+                return n * 2
+
+        self.test_module.Util = Util
+        autovalidate(module=self.test_module, decorator=marking_decorator)
+
+        result = self.test_module.Util.double(7)
+        self.assertEqual(result, 14)
+        self.assertIn("double", wrapped)
+
+    def test_custom_decorator_type_checkers_and_raise_exceptions_ignored(self):
+        """When decorator= is supplied, type_checkers and raise_exceptions have no effect —
+        only the custom decorator's own logic applies."""
+
+        def passthrough_decorator(fn):
+            # Does zero validation; simply calls the function
+            def wrapper(*args, **kwargs):
+                return fn(*args, **kwargs)
+            return wrapper
+
+        def typed_fn(x: int) -> int:
+            return x
+
+        self.test_module.typed_fn = typed_fn
+        autovalidate(
+            module=self.test_module,
+            decorator=passthrough_decorator,
+            raise_exceptions=True,   # would normally raise on bad input
+            type_checkers={int: lambda v: isinstance(v, int)},
+        )
+
+        # The passthrough bypasses all validation, so a bad call must NOT raise
+        result = self.test_module.typed_fn("not-an-int")
+        self.assertEqual(result, "not-an-int")
+
+    def test_custom_decorator_non_callable_raises_type_error(self):
+        """Passing a non-callable as decorator raises TypeError."""
+        def fn(x: int) -> int:
+            return x
+
+        self.test_module.fn = fn
+
+        with self.assertRaises(TypeError):
+            autovalidate(module=self.test_module, decorator="not_a_function")
+
+    def test_custom_decorator_dry_run_does_not_call_decorator(self):
+        """dry_run=True with a custom decorator must not invoke the decorator."""
+        applied = []
+
+        def spy(fn):
+            applied.append(fn.__name__)
+            return fn
+
+        def typed(x: int) -> int:
+            return x
+
+        self.test_module.typed = typed
+        result = autovalidate(module=self.test_module, decorator=spy, dry_run=True)
+
+        # The name should be reported as a candidate ...
+        self.assertIn("test_module.typed", result)
+        # ... but the decorator itself must not have been called
+        self.assertEqual(applied, [])
+
+    def test_custom_decorator_ignored_names_not_decorated(self):
+        """Functions on the ignore list are not passed to the custom decorator."""
+        applied = []
+
+        def spy(fn):
+            applied.append(fn.__name__)
+            return fn
+
+        def secret(x: int) -> int:
+            return x
+
+        self.test_module.secret = secret
+        autovalidate(
+            module=self.test_module,
+            decorator=spy,
+            ignore=["test_module.secret"],
+        )
+
+        self.assertNotIn("secret", applied)
+
+    # ------------------------------------------------------------------
+    # enforce_hints= tests
+    # ------------------------------------------------------------------
+
+    def test_enforce_hints_raises_for_unannotated_function(self):
+        """enforce_hints=True raises TypeError when an eligible function has no annotations."""
+        def no_hints(x, y):
+            return x + y
+
+        self.test_module.no_hints = no_hints
+
+        with self.assertRaises(TypeError) as ctx:
+            autovalidate(module=self.test_module, enforce_hints=True)
+
+        self.assertIn("no_hints", str(ctx.exception))
+        self.assertIn("enforce_hints", str(ctx.exception))
+
+    def test_enforce_hints_passes_when_all_functions_annotated(self):
+        """enforce_hints=True succeeds silently when every eligible function is annotated."""
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        def mul(a: int, b: int) -> int:
+            return a * b
+
+        self.test_module.add = add
+        self.test_module.mul = mul
+
+        # Should not raise
+        decorated = autovalidate(module=self.test_module, enforce_hints=True)
+
+        self.assertIn("test_module.add", decorated)
+        self.assertIn("test_module.mul", decorated)
+
+    def test_enforce_hints_error_message_names_function(self):
+        """The TypeError message includes the fully-qualified function name."""
+        def calculate(x, y):
+            return x - y
+
+        self.test_module.calculate = calculate
+
+        with self.assertRaises(TypeError) as ctx:
+            autovalidate(module=self.test_module, enforce_hints=True)
+
+        self.assertIn("test_module.calculate", str(ctx.exception))
+
+    def test_enforce_hints_ignored_functions_exempt_from_check(self):
+        """Functions on the ignore list are not subject to enforce_hints."""
+        def no_hints(x, y):
+            return x + y
+
+        def has_hints(a: int) -> int:
+            return a
+
+        self.test_module.no_hints = no_hints
+        self.test_module.has_hints = has_hints
+
+        # no_hints is ignored, so enforce_hints must not raise for it
+        decorated = autovalidate(
+            module=self.test_module,
+            enforce_hints=True,
+            ignore=["test_module.no_hints"],
+        )
+
+        self.assertIn("test_module.has_hints", decorated)
+
+    def test_enforce_hints_unannotated_method_raises(self):
+        """enforce_hints=True triggers for unannotated instance methods."""
+        class Processor:
+            def run(self, x, y):   # no annotations
+                return x + y
+
+        self.test_module.Processor = Processor
+
+        with self.assertRaises(TypeError) as ctx:
+            autovalidate(module=self.test_module, enforce_hints=True)
+
+        self.assertIn("run", str(ctx.exception))
+
+    def test_enforce_hints_false_is_default_behaviour(self):
+        """enforce_hints defaults to False; unannotated functions are silently skipped."""
+        def no_hints(x, y):
+            return x + y
+
+        self.test_module.no_hints = no_hints
+
+        # Must not raise, and the unannotated function must not appear in the returned list
+        decorated = autovalidate(module=self.test_module)
+        self.assertNotIn("test_module.no_hints", decorated)
+
+    def test_enforce_hints_dry_run_still_raises(self):
+        """enforce_hints=True combined with dry_run=True still raises before any mutation."""
+        def no_hints(x, y):
+            return x + y
+
+        self.test_module.no_hints = no_hints
+
+        with self.assertRaises(TypeError):
+            autovalidate(module=self.test_module, enforce_hints=True, dry_run=True)
+
+        # Confirm the module was not mutated (original function still in place)
+        self.assertIs(self.test_module.no_hints, no_hints)
+
+    def test_enforce_hints_with_custom_decorator_still_raises(self):
+        """enforce_hints= interacts with decorator=: missing annotations still raise."""
+        def passthrough(fn):
+            return fn
+
+        def no_hints(x, y):
+            return x + y
+
+        self.test_module.no_hints = no_hints
+
+        with self.assertRaises(TypeError):
+            autovalidate(
+                module=self.test_module,
+                decorator=passthrough,
+                enforce_hints=True,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_autovalidate_package.py
+++ b/tests/test_autovalidate_package.py
@@ -8,6 +8,8 @@ import tempfile
 import types
 import unittest
 import textwrap
+import re
+
 from decimal import Decimal
 
 from validatedata import ValidationError, autovalidate_package
@@ -303,6 +305,241 @@ class TestAutovalidatePackage(unittest.TestCase):
                 temp_mod.price_total(1.23)
         finally:
             del sys.modules["temp_mod_decimal"]
+
+    # ------------------------------------------------------------------
+    # decorator= tests
+    # ------------------------------------------------------------------
+
+    def test_custom_decorator_replaces_validate_types_across_package(self):
+        """A custom decorator is applied to every eligible function in the package."""
+        calls = []
+
+        def tracking_decorator(fn):
+            def wrapper(*args, **kwargs):
+                calls.append(fn.__name__)
+                return fn(*args, **kwargs)
+            return wrapper
+
+        autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            exclude=[f"{self.pkg_name}.tests_mod"],
+            decorator=tracking_decorator,
+        )
+
+        mod_a = importlib.import_module(f"{self.pkg_name}.mod_a")
+        mod_a.add(1, 2)
+
+        self.assertIn("add", calls)
+
+    def test_custom_decorator_bypasses_validate_types_validation(self):
+        """With a passthrough decorator, no ValidationError is raised for bad input."""
+
+        def passthrough(fn):
+            def wrapper(*args, **kwargs):
+                return fn(*args, **kwargs)
+            return wrapper
+
+        autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            decorator=passthrough,
+        )
+
+        mod_a = importlib.import_module(f"{self.pkg_name}.mod_a")
+        # add("x", "y") is type-wrong but passthrough does no validation
+        try:
+            mod_a.add("x", "y")
+        except ValidationError:
+            self.fail(
+                "Custom passthrough decorator should not raise ValidationError"
+            )
+
+    def test_custom_decorator_applied_to_nested_subpackage(self):
+        """Custom decorator reaches functions in nested subpackages."""
+        applied = []
+
+        def spy(fn):
+            applied.append(fn.__name__)
+            return fn
+
+        autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            decorator=spy,
+        )
+
+        self.assertIn("echo", applied)
+
+    def test_custom_decorator_dry_run_does_not_call_decorator(self):
+        """dry_run=True must not invoke the custom decorator."""
+        applied = []
+
+        def spy(fn):
+            applied.append(fn.__name__)
+            return fn
+
+        result = autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            decorator=spy,
+            dry_run=True,
+        )
+
+        # Candidates should be reported …
+        self.assertIn(f"{self.pkg_name}.mod_a.add", result["decorated"])
+        # … but the decorator itself must not have been invoked
+        self.assertEqual(applied, [])
+
+    def test_custom_decorator_non_callable_raises_type_error(self):
+        """Passing a non-callable as decorator raises TypeError immediately."""
+        with self.assertRaises(TypeError):
+            autovalidate_package(
+                package=self.pkg_name,
+                decorator="not_a_function",
+            )
+
+    def test_custom_decorator_exclude_pattern_still_honoured(self):
+        """Excluded functions are not passed to the custom decorator."""
+        applied = []
+
+        def spy(fn):
+            applied.append(fn.__name__)
+            return fn
+
+        autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            exclude=[f"{self.pkg_name}.mod_a"],
+            decorator=spy,
+        )
+
+        self.assertNotIn("add", applied)
+
+    def test_custom_decorator_type_checkers_and_raise_exceptions_unused(self):
+        """When decorator= is set, type_checkers and raise_exceptions have no bearing
+        on validation — only the custom decorator's own behaviour matters."""
+
+        def no_op(fn):
+            # deliberately ignores annotations; always passes through
+            def wrapper(*args, **kwargs):
+                return fn(*args, **kwargs)
+            return wrapper
+
+        autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            decorator=no_op,
+            raise_exceptions=True,
+            type_checkers={int: lambda v: isinstance(v, int)},
+        )
+
+        mod_a = importlib.import_module(f"{self.pkg_name}.mod_a")
+        # Wrong types should not raise because the no_op decorator does no validation
+        try:
+            mod_a.add("a", "b")
+        except ValidationError:
+            self.fail("raise_exceptions/type_checkers should be ignored with decorator=")
+
+    # ------------------------------------------------------------------
+    # enforce_hints= tests
+    # ------------------------------------------------------------------
+
+    def test_enforce_hints_raises_for_unannotated_function_in_package(self):
+        """enforce_hints=True raises TypeError when an unannotated eligible function is
+        found, naming the offending fully-qualified function."""
+        # tests_mod.helper has no annotations and is not excluded here
+        with self.assertRaises(TypeError) as ctx:
+            autovalidate_package(
+                package=self.pkg_name,
+                include=[f"{self.pkg_name}.*"],
+                enforce_hints=True,
+            )
+
+        self.assertIn("enforce_hints", str(ctx.exception))
+
+    def test_enforce_hints_passes_when_unannotated_module_excluded(self):
+        """enforce_hints=True does not raise when the unannotated module is excluded."""
+        # Exclude both tests_mod (no annotations) and badmod (import error) so
+        # only mod_a and subpkg remain, which are fully annotated.
+        # Also exclude the unannotated classmethod UserModel.validate.   # <-- added comment
+        result = autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            exclude=[
+                f"{self.pkg_name}.tests_mod",
+                f"{self.pkg_name}.badmod",
+                re.compile(rf"{self.pkg_name}\.mod_a\.UserModel\.validate$"),   # <-- added line
+            ],
+            enforce_hints=True,
+        )
+
+        self.assertIn(f"{self.pkg_name}.mod_a.add", result["decorated"])
+        self.assertIn(f"{self.pkg_name}.subpkg.mod_b.echo", result["decorated"])
+
+    def test_enforce_hints_error_contains_fully_qualified_name(self):
+        """The TypeError message names the fully-qualified offending function."""
+        # Write a helper module with one unannotated function that won't hit
+        # a badmod import error first (walk order is alphabetical).
+        _write_file(
+            os.path.join(self.pkg_dir, "aaa_mod.py"),
+            textwrap.dedent(
+                """
+                def bare(x, y):
+                    return x + y
+                """
+            ).lstrip(),
+        )
+        self._cleanup_imports()
+
+        with self.assertRaises(TypeError) as ctx:
+            autovalidate_package(
+                package=self.pkg_name,
+                include=[f"{self.pkg_name}.aaa_mod"],
+                enforce_hints=True,
+            )
+
+        self.assertIn(f"{self.pkg_name}.aaa_mod.bare", str(ctx.exception))
+
+    def test_enforce_hints_dry_run_still_raises(self):
+        """dry_run=True does not suppress the enforce_hints TypeError."""
+        with self.assertRaises(TypeError):
+            autovalidate_package(
+                package=self.pkg_name,
+                include=[f"{self.pkg_name}.tests_mod"],
+                enforce_hints=True,
+                dry_run=True,
+            )
+
+    def test_enforce_hints_false_is_default_behaviour(self):
+        """Default behaviour (enforce_hints=False) silently skips unannotated functions."""
+        result = autovalidate_package(
+            package=self.pkg_name,
+            include=[f"{self.pkg_name}.*"],
+            dry_run=True,
+        )
+
+        # tests_mod.helper has no annotations; it must appear in skipped, not decorated
+        helper_name = f"{self.pkg_name}.tests_mod.helper"
+        self.assertNotIn(helper_name, result["decorated"])
+        self.assertTrue(
+            any(name == helper_name or "tests_mod" in name for name, _ in result["skipped"])
+        )
+
+    def test_enforce_hints_with_custom_decorator_still_raises(self):
+        """enforce_hints= and decorator= are orthogonal: missing annotations still raise
+        even when a custom decorator is supplied."""
+
+        def passthrough(fn):
+            return fn
+
+        with self.assertRaises(TypeError):
+            autovalidate_package(
+                package=self.pkg_name,
+                include=[f"{self.pkg_name}.tests_mod"],
+                decorator=passthrough,
+                enforce_hints=True,
+            )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "validatedata"
-version = "0.5.2"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },

--- a/validatedata/__init__.py
+++ b/validatedata/__init__.py
@@ -6,7 +6,7 @@ from .autovalidate_package import autovalidate_package
 from .fast import validate_data_fast
 from .types import register_type, unregister_type, export_registered_checkers
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 __all__ = [
     'validate',

--- a/validatedata/autovalidate.py
+++ b/validatedata/autovalidate.py
@@ -5,12 +5,15 @@ from typing import Any, Callable, Dict, List, Optional, Pattern, Union
 
 from validatedata import validate_types
 
+
 def autovalidate(
     module: Union[object, str, None] = None,
     ignore: Optional[List[Union[str, Pattern]]] = None,
     type_checkers: Optional[Dict[Any, Callable[[Any], bool]]] = None,
     raise_exceptions: bool = True,
     dry_run: bool = False,
+    decorator: Optional[Callable] = None,
+    enforce_hints: bool = False,
 ) -> List[str]:
     """
     Automatically apply @validate_types to all callables with type hints in a module.
@@ -23,6 +26,15 @@ def autovalidate(
         dry_run: If True, do not mutate module/class objects; return list of names that
                  would be decorated. If False, perform decoration and return list of
                  decorated names.
+        decorator: Optional callable to use in place of validate_types. When provided it
+                   is called with the target function as its sole argument and must return
+                   the replacement callable (i.e. it should be a plain decorator, not a
+                   decorator factory). ``type_checkers`` and ``raise_exceptions`` are
+                   ignored when a custom decorator is supplied.
+        enforce_hints: When True, raise ``TypeError`` for any eligible function that has
+                       *no* type annotations on any of its parameters. Functions that are
+                       skipped for other reasons (dunder, ignored, already decorated, etc.)
+                       are not subject to this check.
     Returns:
         List of fully qualified names that were (or would be) decorated.
     """
@@ -77,13 +89,6 @@ def autovalidate(
         except (ValueError, TypeError):
             return obj, None  # built-in or C function or otherwise uninspectable
 
-        # Only decorate if any parameter has an annotation
-        has_hints = any(
-            p.annotation != inspect.Parameter.empty for p in sig.parameters.values()
-        )
-        if not has_hints:
-            return obj, None
-
         full_name = (
             f"{parent_full_name}.{name}"
             if parent_full_name
@@ -95,22 +100,49 @@ def autovalidate(
         if _is_already_decorated(obj):
             return obj, None
 
-        # Merge provided type_checkers with registered checkers from validatedata.types
-        merged_checkers = dict(type_checkers or {})
-        try:
-            from validatedata.types import export_registered_checkers
-            merged_checkers.update(export_registered_checkers())
-        except Exception:
-            # fallback to provided checkers only
-            pass
-        
-        decorator = validate_types(
-            raise_exceptions=raise_exceptions,
-            type_checkers=merged_checkers,
+        # Check annotation presence — enforce_hints raises for eligible unannotated functions
+        has_hints = any(
+            p.annotation != inspect.Parameter.empty for p in sig.parameters.values()
         )
+        if not has_hints:
+            if enforce_hints:
+                raise TypeError(
+                    f"enforce_hints=True: '{full_name}' has no type annotations. "
+                    "Add annotations or add it to the ignore list."
+                )
+            return obj, None
 
+        # Build the decorated version using the custom decorator or validate_types
+        if decorator is not None:
+            # Custom decorator: called as decorator(fn) → wrapped fn
+            if not callable(decorator):
+                raise TypeError(
+                    f"'decorator' must be callable, got {type(decorator).__name__!r}"
+                )
 
-        decorated = decorator(obj)
+            if not dry_run:
+                decorated = decorator(obj)
+            else:
+                decorated = obj
+        else:
+            # Default: validate_types, merged with any registered checkers
+            merged_checkers = dict(type_checkers or {})
+            try:
+                from validatedata.types import export_registered_checkers
+
+                merged_checkers.update(export_registered_checkers())
+            except Exception:
+                pass
+
+            _decorator = validate_types(
+                raise_exceptions=raise_exceptions,
+                type_checkers=merged_checkers,
+            )
+
+            if not dry_run:
+                decorated = _decorator(obj)
+            else:
+                decorated = obj
 
         # Mark decorated wrapper so we don't double-decorate later
         _mark_decorated(decorated)

--- a/validatedata/autovalidate_package.py
+++ b/validatedata/autovalidate_package.py
@@ -126,6 +126,43 @@ def autovalidate_package(
     def _is_already_decorated(fn):
         return getattr(fn, "_autovalidated", False)
 
+    def _build_decorated_fn(raw: Callable) -> Callable:
+        """Apply decorator or validate_types to *raw* and return the wrapped function."""
+        if decorator is not None:
+            return decorator(raw)
+        merged_checkers = dict(base_type_checkers)
+        try:
+            merged_checkers.update(types_registry.export_registered_checkers())
+        except Exception:
+            pass
+        _dec = validate_types(
+            raise_exceptions=raise_exceptions,
+            type_checkers=merged_checkers,
+        )
+        return _dec(raw)
+
+    def _check_filter(
+        full_name: str,
+        module_level_included: bool,
+        module_level_excluded: bool,
+    ) -> Optional[str]:
+        """
+        Return a skip-reason string if *full_name* should be skipped, else None.
+
+        Encodes the three-way include/exclude logic shared by methods and functions.
+        """
+        if module_level_excluded:
+            return "excluded by module-level exclude"
+        if module_level_included:
+            if exclude_compiled and _matches_any(full_name, exclude_compiled):
+                return "excluded by exclude pattern"
+        else:
+            if exclude_compiled and _matches_any(full_name, exclude_compiled):
+                return "excluded by exclude pattern"
+            if include_compiled and not _matches_any(full_name, include_compiled):
+                return "not matched by include"
+        return None
+
     decorated: List[str] = []
     skipped: List[Tuple[str, str]] = []
     import_errors: List[Tuple[str, str]] = []
@@ -276,31 +313,12 @@ def autovalidate_package(
                     )
 
                     full_name = f"{module_name}.{obj.__qualname__}.{method_name}"
-                    # Module-level exclude wins: skip all members of the module
-                    if module_level_excluded:
-                        skipped.append((full_name, "excluded by module-level exclude"))
+                    skip_reason = _check_filter(
+                        full_name, module_level_included, module_level_excluded
+                    )
+                    if skip_reason:
+                        skipped.append((full_name, skip_reason))
                         continue
-
-                    # If the module was explicitly included, allow members unless
-                    # a more specific exclude matches the member full name.
-                    if module_level_included:
-                        if exclude_compiled and _matches_any(
-                            full_name, exclude_compiled
-                        ):
-                            skipped.append((full_name, "excluded by exclude pattern"))
-                            continue
-                    else:
-                        # Module not explicitly included: require member-level include
-                        if exclude_compiled and _matches_any(
-                            full_name, exclude_compiled
-                        ):
-                            skipped.append((full_name, "excluded by exclude pattern"))
-                            continue
-                        if include_compiled and not _matches_any(
-                            full_name, include_compiled
-                        ):
-                            skipped.append((full_name, "not matched by include"))
-                            continue
 
                     if not has_hints:
                         if enforce_hints:
@@ -311,29 +329,7 @@ def autovalidate_package(
                         skipped.append((full_name, "no annotations"))
                         continue
 
-                    if decorator is not None:
-                        if not dry_run:
-                            decorated_fn = decorator(raw)
-                        else:
-                            decorated_fn = raw
-                    else:
-                        merged_checkers = dict(base_type_checkers)
-                        try:
-                            merged_checkers.update(
-                                types_registry.export_registered_checkers()
-                            )
-                        except Exception:
-                            pass
-                        _dec = validate_types(
-                            raise_exceptions=raise_exceptions,
-                            type_checkers=merged_checkers,
-                        )
-
-                        if not dry_run:
-                            decorated_fn = _dec(raw)
-                        else:
-                            decorated_fn = raw
-
+                    decorated_fn = raw if dry_run else _build_decorated_fn(raw)
                     _mark_decorated(decorated_fn)
 
                     decorated.append(full_name)
@@ -366,27 +362,12 @@ def autovalidate_package(
                 )
 
                 full_name = f"{module_name}.{name}"
-                # Module-level exclude wins: skip all members of the module
-                if module_level_excluded:
-                    skipped.append((full_name, "excluded by module-level exclude"))
+                skip_reason = _check_filter(
+                    full_name, module_level_included, module_level_excluded
+                )
+                if skip_reason:
+                    skipped.append((full_name, skip_reason))
                     continue
-
-                # If the module was explicitly included, allow members unless
-                # a more specific exclude matches the member full name.
-                if module_level_included:
-                    if exclude_compiled and _matches_any(full_name, exclude_compiled):
-                        skipped.append((full_name, "excluded by exclude pattern"))
-                        continue
-                else:
-                    # Module not explicitly included: require member-level include
-                    if exclude_compiled and _matches_any(full_name, exclude_compiled):
-                        skipped.append((full_name, "excluded by exclude pattern"))
-                        continue
-                    if include_compiled and not _matches_any(
-                        full_name, include_compiled
-                    ):
-                        skipped.append((full_name, "not matched by include"))
-                        continue
 
                 if not has_hints:
                     if enforce_hints:
@@ -397,24 +378,7 @@ def autovalidate_package(
                     skipped.append((full_name, "no annotations"))
                     continue
 
-                if decorator is not None:
-                    if not dry_run:
-                        decorated_fn = decorator(raw)
-                    else:
-                        decorated_fn = raw
-
-                else:
-                    # Merge base checkers and registry checkers so validate_types can use registered types
-                    merged_checkers = dict(base_type_checkers)
-                    try:
-                        merged_checkers.update(getattr(types_registry, "_BY_OBJ", {}))
-                        merged_checkers.update(getattr(types_registry, "_BY_NAME", {}))
-                    except Exception:
-                        pass
-                    _dec = validate_types(
-                        raise_exceptions=raise_exceptions, type_checkers=merged_checkers
-                    )
-                    decorated_fn = _dec(raw)
+                decorated_fn = raw if dry_run else _build_decorated_fn(raw)
                 _mark_decorated(decorated_fn)
 
                 decorated.append(full_name)

--- a/validatedata/autovalidate_package.py
+++ b/validatedata/autovalidate_package.py
@@ -10,8 +10,8 @@ from fnmatch import fnmatch
 from types import ModuleType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Pattern, Tuple, Union
 
-from validatedata import validate_types
 from validatedata import types as types_registry  # validatedata/types.py
+from validatedata import validate_types
 
 PatternOrGlob = Union[str, Pattern]
 
@@ -41,16 +41,42 @@ def autovalidate_package(
     include: Optional[Iterable[PatternOrGlob]] = None,
     exclude: Optional[Iterable[PatternOrGlob]] = None,
     *,
-    type_checkers: Optional[Dict[Any, Callable[[Any], bool]]] = None,
+    type_checkers: Optional[Dict[Any, Callable[[Any, Callable], bool]]] = None,
     raise_exceptions: bool = True,
     dry_run: bool = False,
     auto_register_types: bool = False,
     default_type_name_patterns: Optional[Iterable[str]] = None,
     custom_type_patterns: Optional[Iterable[PatternOrGlob]] = None,
     post_type_validate: bool = False,
+    decorator: Optional[Callable] = None,
+    enforce_hints: bool = False,
 ) -> Dict[str, Any]:
     """
     Walk a package and apply @validate_types to functions/methods in matched modules.
+
+    Args:
+        package: Package object or dotted name string.
+        include: Glob/regex patterns for module or member names to include.
+        exclude: Glob/regex patterns for module or member names to exclude.
+        type_checkers: Custom type validators forwarded to validate_types.
+                       Ignored when ``decorator`` is provided.
+        raise_exceptions: Forwarded to validate_types. Ignored when ``decorator``
+                          is provided.
+        dry_run: If True, return what *would* be decorated without mutating anything.
+        auto_register_types: Discover and register matching classes as custom types
+                             before decorating.
+        default_type_name_patterns: Glob patterns for class names to auto-register
+                                    (default: ``('*Model', '*Entity', '*Type')``).
+        custom_type_patterns: Additional patterns for auto-registration.
+        post_type_validate: Call ``cls.validate(instance)`` inside auto-registered
+                            type checkers.
+        decorator: Optional callable used in place of validate_types. Receives the
+                   raw function as its sole argument and must return the replacement
+                   callable (i.e. a plain decorator, not a factory). When supplied,
+                   ``type_checkers`` and ``raise_exceptions`` are ignored.
+        enforce_hints: When True, raise ``TypeError`` for any eligible function that
+                       has *no* type annotations. Functions skipped for other reasons
+                       (excluded, already decorated, etc.) are exempt.
 
     Returns a dict with keys:
       - decorated: list of fully qualified names decorated
@@ -58,6 +84,10 @@ def autovalidate_package(
       - import_errors: list of (module_name, error_repr)
       - registered_types: list of names registered (if auto_register_types)
     """
+    if decorator is not None and not callable(decorator):
+        raise TypeError(
+            f"'decorator' must be callable, got {type(decorator).__name__!r}"
+        )
     # Resolve package module
     if isinstance(package, str):
         pkg = sys.modules.get(package) or importlib.import_module(package)
@@ -105,7 +135,9 @@ def autovalidate_package(
 
     # Auto-register discovered classes as types if requested
     if auto_register_types:
-        for finder, mod_name, ispkg in pkgutil.walk_packages(pkg.__path__, prefix=pkg.__name__ + "."):
+        for finder, mod_name, ispkg in pkgutil.walk_packages(
+            pkg.__path__, prefix=pkg.__name__ + "."
+        ):
             if not module_allowed(mod_name):
                 continue
             try:
@@ -144,18 +176,25 @@ def autovalidate_package(
                                 except Exception:
                                     return False
                         return True
+
                     return checker
 
                 try:
-                    types_registry.register_type(obj, make_checker(obj), register_names=True, override=False)
+                    types_registry.register_type(
+                        obj, make_checker(obj), register_names=True, override=False
+                    )
                     registered_types.append(f"{obj.__module__}.{obj.__qualname__}")
                 except Exception:
-                    registered_types.append(f"{obj.__module__}.{obj.__qualname__} (already?)")
+                    registered_types.append(
+                        f"{obj.__module__}.{obj.__qualname__} (already?)"
+                    )
 
     # Collect pending updates and apply in second phase
     pending_updates: List[Tuple[object, str, object]] = []
 
-    for finder, mod_name, ispkg in pkgutil.walk_packages(pkg.__path__, prefix=pkg.__name__ + "."):
+    for finder, mod_name, ispkg in pkgutil.walk_packages(
+        pkg.__path__, prefix=pkg.__name__ + "."
+    ):
         if not module_allowed(mod_name):
             skipped.append((mod_name, "excluded by include/exclude"))
             continue
@@ -169,8 +208,12 @@ def autovalidate_package(
         # Module-level include/exclude: if the include matches the module name,
         # allow scanning all members of that module unless a more specific
         # exclude matches the member full name.
-        module_level_included = bool(include_compiled and _matches_any(module_name, include_compiled))
-        module_level_excluded = bool(exclude_compiled and _matches_any(module_name, exclude_compiled))
+        module_level_included = bool(
+            include_compiled and _matches_any(module_name, include_compiled)
+        )
+        module_level_excluded = bool(
+            exclude_compiled and _matches_any(module_name, exclude_compiled)
+        )
 
         for name, obj in list(module.__dict__.items()):
             if name.startswith("__") and name != "__init__":
@@ -179,7 +222,10 @@ def autovalidate_package(
             # Classes
             if inspect.isclass(obj):
                 for method_name, method in list(obj.__dict__.items()):
-                    if method_name.startswith("__") and method_name not in ("__init__", "__call__"):
+                    if method_name.startswith("__") and method_name not in (
+                        "__init__",
+                        "__call__",
+                    ):
                         continue
                     if isinstance(method, property):
                         continue
@@ -196,23 +242,38 @@ def autovalidate_package(
                         raw = method
                         wrapper_kind = "function"
                     else:
-                        skipped.append((f"{module_name}.{obj.__qualname__}.{method_name}", "non-function descriptor"))
+                        skipped.append(
+                            (
+                                f"{module_name}.{obj.__qualname__}.{method_name}",
+                                "non-function descriptor",
+                            )
+                        )
                         continue
 
                     if _is_already_decorated(raw):
-                        skipped.append((f"{module_name}.{obj.__qualname__}.{method_name}", "already decorated"))
+                        skipped.append(
+                            (
+                                f"{module_name}.{obj.__qualname__}.{method_name}",
+                                "already decorated",
+                            )
+                        )
                         continue
 
                     try:
                         sig = inspect.signature(raw)
                     except (ValueError, TypeError):
-                        skipped.append((f"{module_name}.{obj.__qualname__}.{method_name}", "uninspectable"))
+                        skipped.append(
+                            (
+                                f"{module_name}.{obj.__qualname__}.{method_name}",
+                                "uninspectable",
+                            )
+                        )
                         continue
 
-                    has_hints = any(p.annotation != inspect.Parameter.empty for p in sig.parameters.values())
-                    if not has_hints:
-                        skipped.append((f"{module_name}.{obj.__qualname__}.{method_name}", "no annotations"))
-                        continue
+                    has_hints = any(
+                        p.annotation != inspect.Parameter.empty
+                        for p in sig.parameters.values()
+                    )
 
                     full_name = f"{module_name}.{obj.__qualname__}.{method_name}"
                     # Module-level exclude wins: skip all members of the module
@@ -223,36 +284,68 @@ def autovalidate_package(
                     # If the module was explicitly included, allow members unless
                     # a more specific exclude matches the member full name.
                     if module_level_included:
-                        if exclude_compiled and _matches_any(full_name, exclude_compiled):
+                        if exclude_compiled and _matches_any(
+                            full_name, exclude_compiled
+                        ):
                             skipped.append((full_name, "excluded by exclude pattern"))
                             continue
                     else:
                         # Module not explicitly included: require member-level include
-                        if exclude_compiled and _matches_any(full_name, exclude_compiled):
+                        if exclude_compiled and _matches_any(
+                            full_name, exclude_compiled
+                        ):
                             skipped.append((full_name, "excluded by exclude pattern"))
                             continue
-                        if include_compiled and not _matches_any(full_name, include_compiled):
+                        if include_compiled and not _matches_any(
+                            full_name, include_compiled
+                        ):
                             skipped.append((full_name, "not matched by include"))
                             continue
 
+                    if not has_hints:
+                        if enforce_hints:
+                            raise TypeError(
+                                f"enforce_hints=True: '{full_name}' has no type annotations. "
+                                "Add annotations or add it to the exclude list."
+                            )
+                        skipped.append((full_name, "no annotations"))
+                        continue
 
-                    merged_checkers = dict(base_type_checkers)
-                    try:
-                        merged_checkers.update(types_registry.export_registered_checkers())
-                    except Exception:
-                        pass
+                    if decorator is not None:
+                        if not dry_run:
+                            decorated_fn = decorator(raw)
+                        else:
+                            decorated_fn = raw
+                    else:
+                        merged_checkers = dict(base_type_checkers)
+                        try:
+                            merged_checkers.update(
+                                types_registry.export_registered_checkers()
+                            )
+                        except Exception:
+                            pass
+                        _dec = validate_types(
+                            raise_exceptions=raise_exceptions,
+                            type_checkers=merged_checkers,
+                        )
 
+                        if not dry_run:
+                            decorated_fn = _dec(raw)
+                        else:
+                            decorated_fn = raw
 
-                    decorator = validate_types(raise_exceptions=raise_exceptions, type_checkers=merged_checkers)
-                    decorated_fn = decorator(raw)
                     _mark_decorated(decorated_fn)
 
                     decorated.append(full_name)
                     if not dry_run:
                         if wrapper_kind == "classmethod":
-                            pending_updates.append((obj, method_name, classmethod(decorated_fn)))
+                            pending_updates.append(
+                                (obj, method_name, classmethod(decorated_fn))
+                            )
                         elif wrapper_kind == "staticmethod":
-                            pending_updates.append((obj, method_name, staticmethod(decorated_fn)))
+                            pending_updates.append(
+                                (obj, method_name, staticmethod(decorated_fn))
+                            )
                         else:
                             pending_updates.append((obj, method_name, decorated_fn))
 
@@ -267,10 +360,10 @@ def autovalidate_package(
                 except (ValueError, TypeError):
                     skipped.append((f"{module_name}.{name}", "uninspectable"))
                     continue
-                has_hints = any(p.annotation != inspect.Parameter.empty for p in sig.parameters.values())
-                if not has_hints:
-                    skipped.append((f"{module_name}.{name}", "no annotations"))
-                    continue
+                has_hints = any(
+                    p.annotation != inspect.Parameter.empty
+                    for p in sig.parameters.values()
+                )
 
                 full_name = f"{module_name}.{name}"
                 # Module-level exclude wins: skip all members of the module
@@ -289,21 +382,39 @@ def autovalidate_package(
                     if exclude_compiled and _matches_any(full_name, exclude_compiled):
                         skipped.append((full_name, "excluded by exclude pattern"))
                         continue
-                    if include_compiled and not _matches_any(full_name, include_compiled):
+                    if include_compiled and not _matches_any(
+                        full_name, include_compiled
+                    ):
                         skipped.append((full_name, "not matched by include"))
                         continue
 
+                if not has_hints:
+                    if enforce_hints:
+                        raise TypeError(
+                            f"enforce_hints=True: '{full_name}' has no type annotations. "
+                            "Add annotations or add it to the exclude list."
+                        )
+                    skipped.append((full_name, "no annotations"))
+                    continue
 
-                # Merge base checkers and registry checkers so validate_types can use registered types
-                merged_checkers = dict(base_type_checkers)
-                try:
-                    merged_checkers.update(getattr(types_registry, "_BY_OBJ", {}))
-                    merged_checkers.update(getattr(types_registry, "_BY_NAME", {}))
-                except Exception:
-                    pass
+                if decorator is not None:
+                    if not dry_run:
+                        decorated_fn = decorator(raw)
+                    else:
+                        decorated_fn = raw
 
-                decorator = validate_types(raise_exceptions=raise_exceptions, type_checkers=merged_checkers)
-                decorated_fn = decorator(raw)
+                else:
+                    # Merge base checkers and registry checkers so validate_types can use registered types
+                    merged_checkers = dict(base_type_checkers)
+                    try:
+                        merged_checkers.update(getattr(types_registry, "_BY_OBJ", {}))
+                        merged_checkers.update(getattr(types_registry, "_BY_NAME", {}))
+                    except Exception:
+                        pass
+                    _dec = validate_types(
+                        raise_exceptions=raise_exceptions, type_checkers=merged_checkers
+                    )
+                    decorated_fn = _dec(raw)
                 _mark_decorated(decorated_fn)
 
                 decorated.append(full_name)
@@ -319,7 +430,12 @@ def autovalidate_package(
             try:
                 setattr(owner, attr_name, new_obj)
             except Exception as e:
-                skipped.append((f"{getattr(owner, '__name__', repr(owner))}.{attr_name}", f"setattr failed: {e}"))
+                skipped.append(
+                    (
+                        f"{getattr(owner, '__name__', repr(owner))}.{attr_name}",
+                        f"setattr failed: {e}",
+                    )
+                )
 
     return {
         "decorated": decorated,


### PR DESCRIPTION
- adds enforce_hints flag to autovalidate_package
- enables swapping of validate_types for user defined decorator